### PR TITLE
JDK 1.5 compat TimeUnit constants

### DIFF
--- a/src/main/scala/com/twitter/grabbyhands/ConnectionRecv.scala
+++ b/src/main/scala/com/twitter/grabbyhands/ConnectionRecv.scala
@@ -184,11 +184,11 @@ protected[grabbyhands] class ConnectionRecv(
 
     if (queue.transactional) {
       val read = new Read(payload, this)
-      transactionRecvQueue.offer(read, 99999, TimeUnit.HOURS)
+      transactionRecvQueue.put(read)
       if (log.isLoggable(Level.FINEST)) log.finest(connectionName + " awaiting transaction close")
       read.awaitComplete()
     } else {
-      recvQueue.offer(payload, 999999, TimeUnit.HOURS)
+      recvQueue.put(payload)
     }
     if (log.isLoggable(Level.FINEST)) log.finest(connectionName + " message read")
 

--- a/src/main/scala/com/twitter/grabbyhands/Read.scala
+++ b/src/main/scala/com/twitter/grabbyhands/Read.scala
@@ -47,7 +47,7 @@ class Read(val message: ByteBuffer, val connection: ConnectionRecv)
 
   /** Returns only once the transaction has been closed or aborted. */
   def awaitComplete() {
-    openLatch.await(99999, TimeUnit.DAYS)
+    openLatch.await()
   }
 
   /** Returns true if transaction is still open, that is neither completed nor cancelled */

--- a/src/main/scala/com/twitter/grabbyhands/Write.scala
+++ b/src/main/scala/com/twitter/grabbyhands/Write.scala
@@ -43,7 +43,7 @@ class Write(val message: ByteBuffer, val watcher: Boolean => Unit) {
 
   /** Returns only once the message has been sent to a Kestrel. */
   def awaitWrite() {
-    writtenLatch.await(99999, TimeUnit.DAYS)
+    writtenLatch.await()
   }
 
   protected[grabbyhands] def write() {


### PR DESCRIPTION
This gets rid of a few usages of TimeUnit.HOURS and TimeUnit.DAYS, which are new to JDK 1.6 (so that GrabbyHands can be used on JDK 1.5).
