### PR TITLE
Make timed await methods return boolean indication of success v. timeout

### DIFF
--- a/src/main/scala/com/twitter/grabbyhands/Read.scala
+++ b/src/main/scala/com/twitter/grabbyhands/Read.scala
@@ -41,7 +41,7 @@ class Read(val message: ByteBuffer, val connection: ConnectionRecv)
   }
 
   /** Returns only once the transaction has been closed, aborted, or timeout occurs. */
-  def awaitComplete(timeout: Int, units: TimeUnit) {
+  def awaitComplete(timeout: Int, units: TimeUnit) = {
     openLatch.await(timeout, units)
   }
 

--- a/src/main/scala/com/twitter/grabbyhands/Write.scala
+++ b/src/main/scala/com/twitter/grabbyhands/Write.scala
@@ -37,7 +37,7 @@ class Write(val message: ByteBuffer, val watcher: Boolean => Unit) {
   def getWatcher(): Function[Boolean, Unit] = watcher
 
   /** Returns only once the message has been sent to a Kestrel server or timeout occurs. */
-  def awaitWrite(timeout: Int, units: TimeUnit) {
+  def awaitWrite(timeout: Int, units: TimeUnit) = {
     writtenLatch.await(timeout, units)
   }
 


### PR DESCRIPTION
This updates the timed await methods of Read and Write to return a boolean indication of success (so that you can tell if the call completed successfully v. timed out).
